### PR TITLE
Add Fibonacci tokenizer test and simplify magic printing

### DIFF
--- a/tests_ruby/test_tokenizer.rb
+++ b/tests_ruby/test_tokenizer.rb
@@ -1,0 +1,72 @@
+require 'minitest/autorun'
+require_relative '../tokenizer'
+
+class TestTokenizer < Minitest::Test
+  def test_basic
+    text = "hello | world \n (print)"
+    tokens = Tokens.tokenize(text)
+    expected = ['hello', ' ', '|', ' ', 'world', ' ', "\n", ' ', '(', 'print', ')']
+    assert_equal expected, tokens.tokens
+  end
+
+  def test_nontrivial
+    text = (
+      "seq 1 10\n" +
+      "filter (eq 5)\n" +
+      "get 0\n" +
+      "save five\n\n" +
+      "for (i) (seq 0 five) (\n" +
+      "echo i\n\n" +
+      "i | + 2 | echo\n" +
+      ")"
+    )
+    tokens = Tokens.tokenize(text)
+    expected = [
+      'seq', ' ', '1', ' ', '10', "\n", 'filter', ' ', '(', 'eq', ' ', '5', ')', "\n",
+      'get', ' ', '0', "\n", 'save', ' ', 'five', "\n", "\n", 'for', ' ', '(', 'i', ')',
+      ' ', '(', 'seq', ' ', '0', ' ', 'five', ')', ' ', '(', "\n", 'echo', ' ', 'i',
+      "\n", "\n", 'i', ' ', '|', ' ', '+', ' ', '2', ' ', '|', ' ', 'echo', "\n", ')'
+    ]
+    assert_equal expected, tokens.tokens
+  end
+
+  def test_fibonacci_program
+    text = (
+      "function fib (n) (\n" +
+      "if (< n 2) (1)\n" +
+      "else (\n" +
+      "fib (n - 1) |\n" +
+      "fib (n - 2) |\n" +
+      "+ )\n" +
+      ")\n"
+    )
+    tokens = Tokens.tokenize(text)
+    expected = [
+      'function', ' ', 'fib', ' ', '(', 'n', ')', ' ', '(', "\n", 'if', ' ',
+      '(', '<', ' ', 'n', ' ', '2', ')', ' ', '(', '1', ')', "\n", 'else', ' ',
+      '(', "\n", 'fib', ' ', '(', 'n', ' ', '-', ' ', '1', ')', ' ', '|', "\n",
+      'fib', ' ', '(', 'n', ' ', '-', ' ', '2', ')', ' ', '|', "\n", '+', ' ',
+      ')', "\n", ')', "\n"
+    ]
+    assert_equal expected, tokens.tokens
+  end
+
+  def test_peek_and_next
+    tokens = Tokens.tokenize('a b')
+    assert_equal 'a', tokens.peek
+    assert_equal 'a', tokens.next
+    assert_equal ' ', tokens.peek
+    assert_equal ' ', tokens.next
+    assert_equal 'b', tokens.peek
+    assert_equal 'b', tokens.next
+    assert_nil tokens.peek
+    assert_nil tokens.next
+    assert_nil tokens.next
+  end
+
+  def test_to_s
+    tokens = Tokens.tokenize('x y')
+    tokens.next
+    assert_equal [' ', 'y'], eval(tokens.to_s)
+  end
+end

--- a/tests_ruby/test_types.rb
+++ b/tests_ruby/test_types.rb
@@ -1,0 +1,35 @@
+require 'minitest/autorun'
+require_relative '../types'
+
+class TestTypes < Minitest::Test
+  def test_builtin_to_magic
+    assert_equal 'hello', 'hello'.to_magic
+    assert_equal '42', 42.to_magic
+    assert_equal '3.5', 3.5.to_magic
+    assert_equal 'foo', :foo.to_magic
+  end
+
+  def test_linelist
+    list = LineList.new([1, 'a', :b])
+    assert_equal '1 a b', list.to_magic
+  end
+
+  def test_pipelist
+    pipe = PipeList.new([
+      LineList.new([:x]),
+      LineList.new([:y, 2])
+    ])
+    assert_equal "x\ny 2", pipe.to_magic
+  end
+
+  def test_nested_pipe
+    inner = PipeList.new([LineList.new([:z])])
+    outer = LineList.new([:echo, inner])
+    assert_equal 'echo (z)', outer.to_magic
+  end
+
+  def test_value_string_wrapper
+    list = LineList.new([:a, 1])
+    assert_equal 'a 1', Types.value_string(list)
+  end
+end

--- a/tokenizer.rb
+++ b/tokenizer.rb
@@ -1,0 +1,42 @@
+class Tokens
+  attr_reader :tokens
+
+  def initialize(tokens)
+    @tokens = tokens
+    @cur = 0
+  end
+
+  def self.tokenize(text)
+    separators = ['(', ')', "\n", ' ', '|', '"']
+    result = []
+    builder = ''
+    text.each_char do |ch|
+      if separators.include?(ch)
+        unless builder.empty?
+          result << builder
+          builder = ''
+        end
+        result << ch
+      else
+        builder << ch
+      end
+    end
+    result << builder unless builder.empty?
+    new(result)
+  end
+
+  def peek
+    return nil if @cur >= @tokens.length
+    @tokens[@cur]
+  end
+
+  def next
+    tok = peek
+    @cur += 1 if tok
+    tok
+  end
+
+  def to_s
+    @tokens[@cur..-1].inspect
+  end
+end

--- a/types.rb
+++ b/types.rb
@@ -1,0 +1,59 @@
+class LineList < Array
+  def to_magic
+    map do |v|
+      if v.is_a?(PipeList)
+        "(#{v.to_magic})"
+      else
+        v.to_magic
+      end
+    end.join(' ')
+  end
+end
+
+class PipeList < Array
+  def to_magic
+    map { |v| v.to_magic }.join("\n")
+  end
+end
+
+class String
+  def to_magic
+    self
+  end
+end
+
+class Integer
+  def to_magic
+    to_s
+  end
+end
+
+class Float
+  def to_magic
+    to_s
+  end
+end
+
+class Symbol
+  def to_magic
+    to_s
+  end
+end
+
+class TrueClass
+  def to_magic
+    to_s
+  end
+end
+
+class FalseClass
+  def to_magic
+    to_s
+  end
+end
+
+module Types
+  def self.value_string(obj)
+    obj.to_magic
+  end
+end


### PR DESCRIPTION
## Summary
- refine Ruby LineList and PipeList to always call `to_magic`
- simplify `Types.value_string` helper
- add a tokenizer regression test with a Fibonacci example

## Testing
- `pytest -q`
- `ruby tests_ruby/test_tokenizer.rb`
- `ruby tests_ruby/test_types.rb`


------
https://chatgpt.com/codex/tasks/task_e_684b8e2b2b3883279fffc85944b29d29