### PR TITLE
Add Ruby parser and tests

### DIFF
--- a/parse.rb
+++ b/parse.rb
@@ -1,0 +1,79 @@
+require_relative 'tokenizer'
+require_relative 'types'
+
+# Parse *magic* source code into a PipeList AST.
+# Equivalent to the Python reader implementation.
+
+def parse(text)
+  tokens = Tokens.tokenize(text)
+  parsePipe(tokens)
+end
+
+# Parse a sequence of lines until one of the end tokens is encountered.
+
+def parsePipe(tokens, ends = [])
+  ast = PipeList.new
+  while (tok = tokens.peek) && !ends.include?(tok)
+    ast << parseLine(tokens, ends)
+  end
+  ast
+end
+
+# Parse a single line, stopping at a newline or pipe token.
+
+def parseLine(tokens, ends = [])
+  new_lines = ['|', "\n"]
+
+  return LineList.new unless tokens.peek
+
+  if new_lines.include?(tokens.peek)
+    tokens.next
+    return LineList.new
+  end
+
+  ast = LineList.new
+
+  while (tok = tokens.peek) && !new_lines.include?(tok) && !ends.include?(tok)
+    atom = parseAtom(tokens)
+    ast << atom unless atom.nil?
+  end
+
+  tokens.next if tokens.peek && new_lines.include?(tokens.peek)
+
+  ast
+end
+
+# Parse the next primitive or nested block from the token stream.
+
+def parseAtom(tokens)
+  return nil unless tokens.peek
+
+  token = tokens.peek
+
+  case token
+  when '('
+    tokens.next
+    result = parsePipe(tokens, [')'])
+    raise SyntaxError, 'Unclosed parenthesis' unless tokens.peek == ')'
+    tokens.next
+    result
+  when ' '
+    tokens.next
+    nil
+  when 'true'
+    tokens.next
+    true
+  when 'false'
+    tokens.next
+    false
+  else
+    tok = tokens.next
+    if tok.match?(/^-?\d+$/)
+      tok.to_i
+    elsif tok.match?(/^-?\d+\.\d+$/)
+      tok.to_f
+    else
+      tok
+    end
+  end
+end

--- a/tests_ruby/test_reader.rb
+++ b/tests_ruby/test_reader.rb
@@ -1,0 +1,43 @@
+require 'minitest/autorun'
+require_relative '../parse'
+require_relative '../types'
+
+class TestReader < Minitest::Test
+  def roundtrip(src)
+    ast = parse(src)
+    assert_equal ast, parse(Types.value_string(ast))
+  end
+
+  def test_roundtrip_simple
+    ['1 2 | 3', 'eq 0 | or (item | mod 3 | eq 0)'].each do |src|
+      roundtrip(src)
+    end
+  end
+
+  def test_roundtrip_example_file
+    src = File.read('examples/euler1.magic')
+    roundtrip(src)
+  end
+
+  def test_empty_line_roundtrip
+    src = "1\n\n2"
+    ast = parse(src)
+    assert_equal 3, ast.length
+    assert ast[1].is_a?(Array) && ast[1].empty?
+    assert_equal ast, parse(Types.value_string(ast))
+  end
+
+  def test_roundtrip_nontrivial_program
+    src = (
+      "seq 1 10\n" +
+      "filter (eq 5)\n" +
+      "get 0\n" +
+      "save five\n\n" +
+      "for (i) (seq 0 five) (\n" +
+      "echo i\n\n" +
+      "i | + 2 | echo\n" +
+      ")"
+    )
+    roundtrip(src)
+  end
+end


### PR DESCRIPTION
## Summary
- implement parser functions in Ruby
- port Python reader tests to Ruby using the new parser

## Testing
- `pytest -q`
- `ruby -I . tests_ruby/test_tokenizer.rb tests_ruby/test_types.rb tests_ruby/test_reader.rb`


------
https://chatgpt.com/codex/tasks/task_e_684b93d4749c8327b73b5dce40f856a4